### PR TITLE
翻訳前に表示されている内容がどの言語か判別できないのでユーザが設定できるようにした

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <script src="main.js"></script>
 <script>
 $(function() {
-    $.translation({ onlySetLocalStorage: true, currentLang: 'ja'})
+    $.translation({ onlySaveText: true, currentLang: 'ja'})
 
     $('#from-en-to-ja').bind('click', function() {
         var subscriptionKey = $.trim($('#subscription-key').val())

--- a/index.html
+++ b/index.html
@@ -3,6 +3,8 @@
 <script src="main.js"></script>
 <script>
 $(function() {
+    $.translation({ onlySetLocalStorage: true, currentLang: 'ja'})
+
     $('#from-en-to-ja').bind('click', function() {
         var subscriptionKey = $.trim($('#subscription-key').val())
         var omitSelector = $.trim($('#omit-selector').val())

--- a/main.js
+++ b/main.js
@@ -9,21 +9,32 @@
         this.from = options.from || 'ja'
         this.to = options.to || 'en'
         this.omitSelector = options.omitSelector ? options.omitSelector + ',script' : 'script'
+        this.onlySetLocalStorage = options.onlySetLocalStorage
+        this.currentLang = options.currentLang
         this.nodeList = []
+        this.rewiteCount = 0
         this.excute()
     }
 
     Translation.prototype = {
         excute: function() {
-            this.setup()
-            this.hasTranslatedInLocalStorage() ? this.useLocalStorageData() : this.issueAccessToken()
-        },
-        setup: function() {
             this.setTargetNode()
-            this.setLocalStorage()
+            if(this.onlySetLocalStorage) {
+                if(this.currentLang) {
+                    this.setLocalStorage(this.currentLang)
+                } else {
+                    logger.log('incorrect parameter currentLang')
+                }
+            } else {
+                if(this.hasTranslatedInLocalStorage()) {
+                    this.useLocalStorageData()
+                } else {
+                    this.issueAccessToken()
+                }
+            }
         },
         useLocalStorageData: function() {
-            var key = window.location.href + this.from + this.to
+            var key = window.location.href + this.to + this.omitSelector
             var values = JSON.parse(localStorage.getItem(key))
             var count = 0
             logger.log('use localstorage data')
@@ -105,6 +116,8 @@
                     node.nodeValue = results[i].TranslatedText :
                     node.value = results[i].TranslatedText
             })
+            this.rewiteCount += 1
+            if(this.rewiteCount === this.nodeList.length) this.setLocalStorage(this.to)
         },
         setTargetNode: function() {
             var textNodeList = $('body *').not(this.omitSelector).contents().filter(function() {
@@ -129,8 +142,8 @@
                 return '"' + text.replace(/\r?\n/g, ' ') + '"'
             }).join(',')
         },
-        setLocalStorage: function() {
-            var key = window.location.href + this.to + this.from
+        setLocalStorage: function(lang) {
+            var key = window.location.href + lang + this.omitSelector
             var nodeValues = $.map(this.nodeList, function(nodeListBlock) {
                 return $.map(nodeListBlock, function(node) {
                     return node.nodeType === 3 ? node.nodeValue : node.value
@@ -139,7 +152,7 @@
             localStorage.setItem(key, JSON.stringify(nodeValues))
         },
         hasTranslatedInLocalStorage: function() {
-            var key = window.location.href + this.from + this.to
+            var key = window.location.href + this.to + this.omitSelector
             return !!localStorage[key]
         }
     }

--- a/main.js
+++ b/main.js
@@ -9,7 +9,7 @@
         this.from = options.from || 'ja'
         this.to = options.to || 'en'
         this.omitSelector = options.omitSelector ? options.omitSelector + ',script' : 'script'
-        this.onlySetLocalStorage = options.onlySetLocalStorage
+        this.onlySaveText = options.onlySaveText
         this.currentLang = options.currentLang
         this.nodeList = []
         this.rewiteCount = 0
@@ -19,7 +19,7 @@
     Translation.prototype = {
         excute: function() {
             this.setTargetNode()
-            if(this.onlySetLocalStorage) {
+            if(this.onlySaveText) {
                 if(this.currentLang) {
                     this.setLocalStorage(this.currentLang)
                 } else {


### PR DESCRIPTION
* 元のhtmlが日本語の場合、日 -> 英 して 英 -> 日 すると当然であるが元の日本語とは違った日本語が表示されてしまう
* 翻訳実行時に実行前の状態をlocalstorageに入れておこうと思ったけど、ユーザが実行時に指定したfromの言語と画面に表示される言語が一致しているとは限らない
  * 日本語が表示されているのに 英 -> 日 を誤って実行してしまったような場合
* なのでユーザが明示的に言語を指定して、表示されている内容を保存する必要がある

* 使い方の想定としては、まずロード時に現状の保存のみ実行
````javascript
$.translation({ onlySaveText: true, currentLang: 'ja', ommitSelector: '.omit-translate' });
````
* その後ボタンクリック等任意のタイミングで翻訳を実行
````javascript
$('#english').click(function() {
    $.translation({ from: 'ja', to: 'en', ommitSelector: '.omit-translate' });
}
````
* 翻訳実行時は翻訳後のデータがlocalstorageにあればそれをそのまま画面に反映
なければMS Translatorで翻訳しlocalstorageに保存して画面に反映




